### PR TITLE
Add MSCD support for Windows 2000 cdplayer.exe

### DIFF
--- a/src/lib/cdigw_web/endpoint.ex
+++ b/src/lib/cdigw_web/endpoint.ex
@@ -10,6 +10,10 @@ defmodule CdigwWeb.Endpoint do
     CdigwWeb.CddbPlug.call(conn, %{})
   end
 
+  match "/mscd/" do
+    CdigwWeb.MscdPlug.call(conn, %{})
+  end
+
   match "/" do
     conn
     |> put_resp_content_type("text/html")

--- a/src/lib/cdigw_web/mscd_plug.ex
+++ b/src/lib/cdigw_web/mscd_plug.ex
@@ -1,0 +1,19 @@
+defmodule CdigwWeb.MscdPlug do
+  import Plug.Conn
+  require Logger
+
+
+  def init(options), do: options
+
+  def call(conn, _opts) do
+    conn = fetch_query_params(conn)
+
+    toc = Mscd.RequestParser.parse_query(conn.query_params["cd"])
+    mb_disc_id = MusicBrainz.calculate_disc_id(toc.lead_out_lba, toc.track_lbas)
+    {:ok, %{"releases" => [release | _]}} = MusicBrainz.get_releases_by_disc_id(mb_disc_id)
+    disc = MusicBrainz.release_to_disc(nil, release)
+    response = Mscd.Response.render(disc)
+
+    conn |> send_resp(200, response)
+  end
+end

--- a/src/lib/cdigw_web/mscd_plug.ex
+++ b/src/lib/cdigw_web/mscd_plug.ex
@@ -2,7 +2,6 @@ defmodule CdigwWeb.MscdPlug do
   import Plug.Conn
   require Logger
 
-
   def init(options), do: options
 
   def call(conn, _opts) do

--- a/src/lib/mscd/request_parser.ex
+++ b/src/lib/mscd/request_parser.ex
@@ -1,5 +1,4 @@
 defmodule Mscd.RequestParser do
-
   @doc """
       iex> Mscd.RequestParser.parse_query("D 96 3B87 73B9 B2C3 EFEC 12856 165FA 1A976 1E332 22277 257F5 29517 2E04F 32110")
       %{
@@ -11,7 +10,7 @@ defmodule Mscd.RequestParser do
   def parse_query(query) when is_binary(query) do
     query
     |> String.split(" ", trim: true)
-    |> Enum.map(&(String.to_integer(&1, 16)))
+    |> Enum.map(&String.to_integer(&1, 16))
     |> parse_query()
   end
 

--- a/src/lib/mscd/request_parser.ex
+++ b/src/lib/mscd/request_parser.ex
@@ -1,0 +1,23 @@
+defmodule Mscd.RequestParser do
+
+  @doc """
+      iex> Mscd.RequestParser.parse_query("D 96 3B87 73B9 B2C3 EFEC 12856 165FA 1A976 1E332 22277 257F5 29517 2E04F 32110")
+      %{
+        track_count: 13,
+        track_lbas: [150, 15239, 29625, 45763, 61420, 75862, 91642, 108918, 123698, 139895, 153589, 169239, 188495],
+        lead_out_lba: 205072
+      }
+  """
+  def parse_query(query) when is_binary(query) do
+    query
+    |> String.split(" ", trim: true)
+    |> Enum.map(&(String.to_integer(&1, 16)))
+    |> parse_query()
+  end
+
+  def parse_query([track_count | lbas]) do
+    {track_lbas, [lead_out_lba]} = Enum.split(lbas, track_count)
+
+    %{track_count: track_count, track_lbas: track_lbas, lead_out_lba: lead_out_lba}
+  end
+end

--- a/src/lib/mscd/response.ex
+++ b/src/lib/mscd/response.ex
@@ -22,6 +22,7 @@ defmodule Mscd.Response do
       Title: title,
       Artist: artist
     ]
+
     track_titles =
       tracks
       |> Enum.with_index(1)

--- a/src/lib/mscd/response.ex
+++ b/src/lib/mscd/response.ex
@@ -1,0 +1,32 @@
+defmodule Mscd.Response do
+  alias Cddb.Disc
+
+  @certificate "41d602112509916cb8f45f81164805e29bfef1946c88dc57"
+  @line_separator "\n"
+
+  def render(%Disc{} = disc) do
+    body =
+      disc
+      |> render_fields()
+      |> Enum.map(fn {key, value} -> "#{key}=#{value}" end)
+
+    body = ["[CD]" | body]
+
+    Enum.join(body, @line_separator)
+  end
+
+  def render_fields(%Disc{title: title, artist: artist, tracks: tracks} = disc) do
+    parts = [
+      CERTIFICATE: @certificate,
+      Mode: 0,
+      Title: title,
+      Artist: artist
+    ]
+    track_titles =
+      tracks
+      |> Enum.with_index(1)
+      |> Enum.map(fn {{title, _other}, index} -> {:"Track#{index}", title} end)
+
+    parts ++ track_titles
+  end
+end

--- a/src/lib/music_brainz.ex
+++ b/src/lib/music_brainz.ex
@@ -100,10 +100,10 @@ defmodule MusicBrainz do
     end
   end
 
-  def get_release(id, inc \\ @default_inc) do
+  def get_releases_by_disc_id(id, inc \\ @default_inc) do
     inc_list = Enum.join(inc, "+")
 
-    case get("/release/#{id}/?fmt=json&inc=#{inc_list}") do
+    case get("/discid/#{id}/?fmt=json&inc=#{inc_list}") do
       {:ok, %{status: 200, body: body}} ->
         {:ok, body}
 

--- a/src/test/mscd/request_parser_test.exs
+++ b/src/test/mscd/request_parser_test.exs
@@ -1,0 +1,7 @@
+defmodule Mscd.RequestParserTest do
+  use ExUnit.Case, async: true
+
+  alias Mscd.RequestParser
+
+  doctest RequestParser
+end


### PR DESCRIPTION
Add support for MSCD, the protocol used by the Windows 2000 cdplayer.exe

Currently the code works with the one disc I've tested and responses generated are correct based on what I've found on the archive.org Wayback Machine.

Unfortunately the Windows 2000 cdplayer still won't accept the responses. I've tried different content types and line endings but no joy. I have an [open question on Stack Overflow](https://stackoverflow.com/questions/61459974/what-response-format-does-the-windows-2000-cdplayer-exe-expect-for-disc-metadata) which I've been promised by the @WindowsDev twitter account will be answered!

Response sample I found on the Wayback Machine

```
[CD]
CERTIFICATE=41d602112509916cb8f45f81164805e29bfef1946c88dc57
Mode=0
Title=SUMMER GIRLS
Artist=LFO
Track1=Summer Girls
Track2=Girl on TV
Track3=Cross My heart
Track4=Cant have you
Track5=I dont wanna Kiss you goodnight
Track6=West Side Story
Track7=Thinking about you
Track8=I will show you mine
Track9=All I need to know
Track10=Baby Be mine
Track11=Your heart is safe with me
Track12=My block
Track13=Forever
Menu1=RollingStone Biography::http://www.tunes.com/mscd.asp?t=b&amp;id=6958
Menu2=RS Photos::http://www.tunes.com/mscd.asp?t=p&amp;id=6958
Menu3=RS Triva::http://www.tunes.com/mscd.asp?t=t&amp;id=6958
Menu4=RS Videos::http://www.tunes.com/mscd.asp?t=v&amp;id=6958
Menu5=RS Discussions::http://www.tunes.com/mscd.asp?t=d&amp;id=6958
Menu6=RS Discography::http://www.tunes.com/mscd.asp?t=disc&amp;id=6958
Menu7=RS Links::http://www.tunes.com/mscd.asp?t=l&amp;id=6958
Menu8=Get Related MP3s::http://www.tunes.com/mscd.asp?t=mp3&amp;id=6958
```

Another sample: https://web.archive.org/web/20000301091748/http://www.tunes.com:80/tunes-cgi2/tunes/disc_info/203/cd=D+96+84CE+C395+F2FB+11702+15127+22B2A+26038+289CC+2CF6D+2FC30+32BB4+450E3+4A29D