### PR TITLE
Move common CDDB logic to Cddb module

### DIFF
--- a/src/lib/cddb/request_parser.ex
+++ b/src/lib/cddb/request_parser.ex
@@ -16,22 +16,47 @@ defmodule Cddb.RequestParser do
   def parse_cmd(["cddb" | cmd]), do: parse_cmd(cmd)
 
   def parse_cmd(["query" | query]) do
-    [disc_id, track_count | tracks] = query
-
-    track_count = String.to_integer(track_count)
-    {tracks, [seconds]} = Enum.split(tracks, track_count)
-    seconds = String.to_integer(seconds)
-
-    {:query,
-     %{
-       disc_id: disc_id,
-       track_count: track_count,
-       disc_length: seconds,
-       track_lbas: Enum.map(tracks, &String.to_integer/1)
-     }}
+    case parse_query(query) do
+      {:ok, disc} -> {:query, disc}
+      other -> other
+    end
   end
 
   def parse_cmd(["read", genre, disc_id]) do
     {:read, %{genre: genre, disc_id: disc_id}}
+  end
+
+  @doc """
+  Parse a query, returning a broken-out structured map.
+  """
+  def parse_query(query) do
+    [disc_id, track_count | tracks] = query
+
+    with {track_count, ""} <- Integer.parse(track_count),
+         {tracks, [seconds]} <- Enum.split(tracks, track_count),
+         tracks = parse_track_list(tracks),
+         {seconds, ""} <- Integer.parse(seconds),
+         ^track_count <- length(tracks) do
+      {:ok,
+       %{
+         disc_id: disc_id,
+         track_count: track_count,
+         track_lbas: tracks,
+         length_seconds: seconds
+       }}
+    else
+      value -> {:error, value}
+    end
+  end
+
+  defp parse_track_list(tracks) do
+    tracks
+    |> Enum.map(&Integer.parse/1)
+    |> Enum.map(fn
+      :error -> nil
+      {num, ""} -> num
+      _ -> nil
+    end)
+    |> Enum.reject(&is_nil/1)
   end
 end

--- a/src/lib/music_brainz.ex
+++ b/src/lib/music_brainz.ex
@@ -80,7 +80,7 @@ defmodule MusicBrainz do
   Since we know what the audio track TOC is though, we can match on it exactly
   to find our disc amongst the multiple results.
   """
-  def find_by_length_and_toc(length_seconds, toc) do
+  def find_release(length_seconds, toc) when is_integer(length_seconds) and is_list(toc) do
     toc = ensure_int_list(toc)
     guessed_leadout_lba = length_seconds * @sectors_per_second
     track_count = length(toc)

--- a/src/test/cddb/request_parser_test.exs
+++ b/src/test/cddb/request_parser_test.exs
@@ -14,7 +14,7 @@ defmodule Cddb.RequestParserTest do
        %{
          disc_id: "940aac0d",
          track_count: 13,
-         disc_length: 2734,
+         length_seconds: 2734,
          track_lbas: [
            150,
            15239,

--- a/src/test/music_brainz_test.exs
+++ b/src/test/music_brainz_test.exs
@@ -69,11 +69,11 @@ defmodule MusicBrainzTest do
   end
 
   @tag capture_log: true
-  test "find_by_length_and_toc/2 when there are multiple disc layouts for the album" do
+  test "find_release/2 when there are multiple disc layouts for the album" do
     length = 4223
     toc = ~w[182 3250 30272 61607 93215 118357 141452 175105 211805 251415 282740]
 
-    {:ok, results} = MusicBrainz.find_by_length_and_toc(length, toc)
+    {:ok, results} = MusicBrainz.find_release(length, toc)
     assert length(results) == 1
   end
 end


### PR DESCRIPTION
Extracted from #5 as this change should exist on its own.

Moves the common CDDB workflow from the web plug to the `Cddb` main module. Also renames a couple things in `MusicBrainz`